### PR TITLE
Added code in KiloCam_V3_LT_ESP32Code_03042024.ino to force FB to be …

### DIFF
--- a/KiloCam_V3_LT_ESP32Code_03042024.ino
+++ b/KiloCam_V3_LT_ESP32Code_03042024.ino
@@ -115,6 +115,8 @@ void setup() {
   
   // Initialize camera 
   camera_config_t config;
+  // force the frame buffer to be in psRAM
+  config.fb_location = CAMERA_FB_IN_PSRAM;
   config.ledc_channel = LEDC_CHANNEL_0;
   config.ledc_timer = LEDC_TIMER_0;
   config.pin_d0 = Y2_GPIO_NUM;
@@ -297,7 +299,9 @@ void setup() {
       //delay(250); // Spacing between photos
   
     }
-
+  // Unmount the SD card
+  SD_MMC.end();
+  
   // Turns off the ESP32-CAM white on-board LED (flash) connected to GPIO 4
   rtc_gpio_hold_en(GPIO_NUM_4);
   digitalWrite(4, LOW);
@@ -310,6 +314,7 @@ void setup() {
 
 void loop() {  
 }
+
 
 
 


### PR DESCRIPTION
…in psRAM and umount SD.  I was having problem when I set the CAM to take UXGA images as it would run out of memory.  Adding CAMERA_FB_IN_PSRAM fix this.  I also noticed that the SD card would say it had not been unmounted properly so I added the SD_MMC.end() to umount the card before it went to sleep.